### PR TITLE
[#3] Add JSON session store and /api/sessions routes

### DIFF
--- a/app/.gitignore
+++ b/app/.gitignore
@@ -32,3 +32,7 @@ yarn-error.log*
 # typescript
 *.tsbuildinfo
 next-env.d.ts
+
+# runtime data
+data/sessions.json
+data/sessions.json.tmp

--- a/app/app/api/sessions/route.ts
+++ b/app/app/api/sessions/route.ts
@@ -1,0 +1,73 @@
+import { NextRequest, NextResponse } from "next/server";
+import { appendSession, getSessionsForToday } from "@/lib/storage";
+
+// ---------------------------------------------------------------------------
+// GET /api/sessions
+// Returns today's sessions (server-local day), newest first.
+// ---------------------------------------------------------------------------
+
+export async function GET(): Promise<NextResponse> {
+  try {
+    const sessions = await getSessionsForToday();
+    return NextResponse.json(
+      { sessions },
+      {
+        status: 200,
+        headers: { "Cache-Control": "no-store" },
+      },
+    );
+  } catch {
+    return NextResponse.json({ error: "storage_error" }, { status: 500 });
+  }
+}
+
+// ---------------------------------------------------------------------------
+// POST /api/sessions
+// Validates request body, appends a new session, and returns 201.
+// ---------------------------------------------------------------------------
+
+export async function POST(request: NextRequest): Promise<NextResponse> {
+  let body: unknown;
+  try {
+    body = await request.json();
+  } catch {
+    return NextResponse.json({ error: "invalid_body" }, { status: 400 });
+  }
+
+  if (
+    typeof body !== "object" ||
+    body === null ||
+    Array.isArray(body)
+  ) {
+    return NextResponse.json({ error: "invalid_body" }, { status: 400 });
+  }
+
+  const raw = body as Record<string, unknown>;
+
+  // Validate mode
+  if (raw.mode !== "focus" && raw.mode !== "break") {
+    return NextResponse.json({ error: "invalid_mode" }, { status: 400 });
+  }
+
+  // Validate durationSeconds: must be a positive integer <= 3600
+  const dur = raw.durationSeconds;
+  if (
+    typeof dur !== "number" ||
+    !Number.isInteger(dur) ||
+    dur <= 0 ||
+    dur > 3600
+  ) {
+    return NextResponse.json({ error: "invalid_duration" }, { status: 400 });
+  }
+
+  try {
+    // id and completedAt are always generated server-side; client values ignored.
+    const session = await appendSession({
+      mode: raw.mode,
+      durationSeconds: dur,
+    });
+    return NextResponse.json(session, { status: 201 });
+  } catch {
+    return NextResponse.json({ error: "storage_error" }, { status: 500 });
+  }
+}

--- a/app/lib/storage.ts
+++ b/app/lib/storage.ts
@@ -1,0 +1,156 @@
+/**
+ * JSON file-based session storage.
+ *
+ * All I/O is serialized through a simple in-process mutex (a Promise chain)
+ * so that concurrent POST requests cannot interleave reads and writes.
+ *
+ * Timezone note: `getSessionsForToday` uses the **server's local timezone**
+ * to determine "today". This is intentional for MVP — all users are local.
+ */
+
+import fs from "fs/promises";
+import path from "path";
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+export type Session = {
+  id: string;
+  mode: "focus" | "break";
+  durationSeconds: number;
+  completedAt: string;
+};
+
+type StorageFile = {
+  sessions: Session[];
+};
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+const DATA_DIR = path.join(process.cwd(), "data");
+const FILE_PATH = path.join(DATA_DIR, "sessions.json");
+const TMP_PATH = path.join(DATA_DIR, "sessions.json.tmp");
+
+const EMPTY_STORE: StorageFile = { sessions: [] };
+
+// ---------------------------------------------------------------------------
+// In-process mutex
+// ---------------------------------------------------------------------------
+
+let mutex: Promise<void> = Promise.resolve();
+
+function withMutex<T>(fn: () => Promise<T>): Promise<T> {
+  const result = mutex.then(fn);
+  // The mutex tail only resolves/rejects after fn resolves/rejects, so
+  // subsequent callers always queue behind the current operation.
+  mutex = result.then(
+    () => undefined,
+    () => undefined,
+  );
+  return result;
+}
+
+// ---------------------------------------------------------------------------
+// Low-level helpers (called from within the mutex)
+// ---------------------------------------------------------------------------
+
+async function ensureDataDir(): Promise<void> {
+  await fs.mkdir(DATA_DIR, { recursive: true });
+}
+
+async function readFile(): Promise<StorageFile> {
+  await ensureDataDir();
+  try {
+    const raw = await fs.readFile(FILE_PATH, "utf-8");
+    return JSON.parse(raw) as StorageFile;
+  } catch (err: unknown) {
+    if (
+      typeof err === "object" &&
+      err !== null &&
+      "code" in err &&
+      (err as NodeJS.ErrnoException).code === "ENOENT"
+    ) {
+      // First access — create the file and return empty store.
+      await writeFile(EMPTY_STORE);
+      return { ...EMPTY_STORE, sessions: [] };
+    }
+    throw err;
+  }
+}
+
+async function writeFile(store: StorageFile): Promise<void> {
+  await ensureDataDir();
+  await fs.writeFile(TMP_PATH, JSON.stringify(store, null, 2), "utf-8");
+  await fs.rename(TMP_PATH, FILE_PATH);
+}
+
+// ---------------------------------------------------------------------------
+// Public API
+// ---------------------------------------------------------------------------
+
+/**
+ * Returns all sessions stored in the JSON file.
+ * Creates the file with an empty store if it does not exist.
+ */
+export async function readAllSessions(): Promise<Session[]> {
+  return withMutex(async () => {
+    const store = await readFile();
+    return store.sessions;
+  });
+}
+
+/**
+ * Appends a new session to the store and returns the persisted session.
+ * `id` and `completedAt` are always generated server-side.
+ */
+export async function appendSession(
+  input: Omit<Session, "id" | "completedAt"> & { completedAt?: string },
+): Promise<Session> {
+  return withMutex(async () => {
+    const store = await readFile();
+
+    const session: Session = {
+      id: crypto.randomUUID(),
+      mode: input.mode,
+      durationSeconds: input.durationSeconds,
+      completedAt: new Date().toISOString(),
+    };
+
+    store.sessions.push(session);
+    await writeFile(store);
+    return session;
+  });
+}
+
+/**
+ * Returns sessions whose `completedAt` timestamp falls on the same local
+ * calendar day as `nowIso` (defaults to `new Date()` if not provided).
+ *
+ * Uses the **server's local timezone** — acceptable for a single-user MVP.
+ */
+export async function getSessionsForToday(
+  nowIso?: string,
+): Promise<Session[]> {
+  const now = nowIso ? new Date(nowIso) : new Date();
+  // Build a YYYY-MM-DD string in local time for "today".
+  const todayLocal = localDateString(now);
+
+  const all = await readAllSessions();
+  return all
+    .filter((s) => localDateString(new Date(s.completedAt)) === todayLocal)
+    .reverse(); // newest first (sessions are appended in chronological order)
+}
+
+// ---------------------------------------------------------------------------
+// Internal helpers
+// ---------------------------------------------------------------------------
+
+function localDateString(date: Date): string {
+  const y = date.getFullYear();
+  const m = String(date.getMonth() + 1).padStart(2, "0");
+  const d = String(date.getDate()).padStart(2, "0");
+  return `${y}-${m}-${d}`;
+}

--- a/app/package-lock.json
+++ b/app/package-lock.json
@@ -2386,6 +2386,7 @@
       "integrity": "sha512-whOE1HFo/qJDyX4SnXzP4N6zOWn79WhnCUY/iDR0mPfQZO8wcYE4JClzI2oZrhBnnMUCBCHZhO6VQyoBU95mZA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@rtsao/scc": "^1.1.0",
         "array-includes": "^3.1.9",


### PR DESCRIPTION
## Summary

- Implements `app/lib/storage.ts` — the JSON file persistence layer for Pomodoro sessions, with atomic writes (tmp-file + `fs.rename`) and an in-process mutex (Promise chain) to serialize concurrent writes.
- Implements `app/app/api/sessions/route.ts` — Next.js App Router route handlers for `GET /api/sessions` and `POST /api/sessions`.
- Adds `app/data/.gitkeep` so the data directory is committed; adds `data/sessions.json` and `data/sessions.json.tmp` to `app/.gitignore` so runtime data is never committed.
- Uses `crypto.randomUUID()` — no new dependencies added.

## Endpoints / schema changes

- `GET /api/sessions` — returns today's sessions (server-local date), newest first, with `Cache-Control: no-store`. Returns `{ sessions: [...] }`.
- `POST /api/sessions` — validates `mode ∈ {focus,break}` and `durationSeconds` is a positive integer ≤ 3600. Generates `id` and `completedAt` server-side; ignores any client-supplied values. Returns 201 with the created session object.
- No new tables — file-based storage at `app/data/sessions.json`.

## Acceptance criteria

- [x] `app/lib/storage.ts` exists and exports `Session`, `readAllSessions`, `appendSession`, `getSessionsForToday` with the signatures specified in the issue.
- [x] Storage auto-creates `app/data/sessions.json` as `{ "sessions": [] }` if missing.
- [x] Writes are atomic (tmp-file + rename) and serialized via a Promise-chain mutex so parallel POSTs don't lose data.
- [x] `GET /api/sessions` returns only sessions from today's local date, newest first, with `Cache-Control: no-store`.
- [x] `POST /api/sessions` with valid body returns 201 and persists the session. Restarting the dev server, then calling GET, still returns the session if it's still "today".
- [x] `POST /api/sessions` with `mode: "lunch"` returns 400 `{ "error": "invalid_mode" }`.
- [x] `POST /api/sessions` with `durationSeconds: -1`, `0`, `4000`, or `"abc"` returns 400 `{ "error": "invalid_duration" }`.
- [x] `POST /api/sessions` generates server-side `id` and `completedAt`; client-supplied values for those are ignored.
- [x] `app/data/sessions.json` is not committed — added to `app/.gitignore`. `app/data/.gitkeep` is committed.
- [x] `npm run lint` passes (no ESLint warnings or errors).
- [x] `npm run build` passes (route appears as `ƒ /api/sessions` in build output).
- [x] Manual verification instructions below.
- [x] PR body contains `Closes #3` and lists acceptance criteria as a checklist.

## How to test locally

```bash
cd app
npm install
npm run dev
```

Then in another terminal:

```bash
# GET with empty store (auto-creates sessions.json)
curl -s http://localhost:3000/api/sessions
# => {"sessions":[]}

# POST a focus session
curl -s -X POST http://localhost:3000/api/sessions \
  -H "Content-Type: application/json" \
  -d '{"mode":"focus","durationSeconds":1500}'
# => {"id":"a8216ae6-ebdc-4c45-9dfa-392012dc9bbd","mode":"focus","durationSeconds":1500,"completedAt":"2026-04-19T18:34:44.522Z"}

# GET — session appears, newest first
curl -s http://localhost:3000/api/sessions
# => {"sessions":[{"id":"a8216ae6-ebdc-4c45-9dfa-392012dc9bbd","mode":"focus","durationSeconds":1500,"completedAt":"2026-04-19T18:34:44.522Z"}]}

# POST a break session
curl -s -X POST http://localhost:3000/api/sessions \
  -H "Content-Type: application/json" \
  -d '{"mode":"break","durationSeconds":300}'
# => {"id":"62d26ae4-5345-4b7b-a504-2dfd915f4df4","mode":"break","durationSeconds":300,"completedAt":"2026-04-19T18:35:11.992Z"}

# GET — both sessions, newest (break) first
curl -s http://localhost:3000/api/sessions
# => {"sessions":[{"id":"62d26ae4-...","mode":"break","durationSeconds":300,...},{"id":"a8216ae6-...","mode":"focus","durationSeconds":1500,...}]}

# Check Cache-Control header
curl -sI http://localhost:3000/api/sessions | grep -i cache-control
# => cache-control: no-store

# Validation — invalid mode
curl -s -X POST http://localhost:3000/api/sessions \
  -H "Content-Type: application/json" \
  -d '{"mode":"lunch","durationSeconds":1500}'
# => {"error":"invalid_mode"}

# Validation — durationSeconds: -1
curl -s -X POST http://localhost:3000/api/sessions \
  -H "Content-Type: application/json" \
  -d '{"mode":"focus","durationSeconds":-1}'
# => {"error":"invalid_duration"}

# Validation — durationSeconds: 0
curl -s -X POST http://localhost:3000/api/sessions \
  -H "Content-Type: application/json" \
  -d '{"mode":"focus","durationSeconds":0}'
# => {"error":"invalid_duration"}

# Validation — durationSeconds: 4000
curl -s -X POST http://localhost:3000/api/sessions \
  -H "Content-Type: application/json" \
  -d '{"mode":"focus","durationSeconds":4000}'
# => {"error":"invalid_duration"}

# Validation — durationSeconds: "abc"
curl -s -X POST http://localhost:3000/api/sessions \
  -H "Content-Type: application/json" \
  -d '{"mode":"focus","durationSeconds":"abc"}'
# => {"error":"invalid_duration"}
```

All outputs above match what was observed during smoke testing.

## New env vars

None.

Closes #3